### PR TITLE
Added support for a prefix, to add in the API key for hosted statsD

### DIFF
--- a/src/iFixit/StatsD.php
+++ b/src/iFixit/StatsD.php
@@ -19,6 +19,13 @@ class StatsD {
     * @var string
     */
    protected static $port = '8125';
+   /**
+    * Optional prefix for a metric's name.
+    * Useful for services that require an API key in the prefix,
+    * e.g. https://www.hostedgraphite.com/
+    * @var string
+    */
+   protected static $prefix = '';
 
 	/**
 	 * Maximum payload we may cramp into a UDP packet
@@ -224,7 +231,7 @@ class StatsD {
       $chunkSize = 0;
       $i = 0; $lineCount = count($lines);
       while ($i < $lineCount) {
-         $line = $lines[$i];
+         $line = static::$prefix . $lines[$i];
          $len = strlen($line) + 1;
          $chunkSize += $len;
          if ($chunkSize > self::MAX_PACKET_SIZE) {


### PR DESCRIPTION
I've added in the ability to add a prefix to each stats line, as there are some services that require a prefix for an API key, e.g. http://docs.hostedgraphite.com/#udp-packets

I've not presumed the "." at the end of the API key, as some users may want to use this prefix for another purpose. Such as specifying the project that the metric originates from, and I don't want to be presumptuous as to how they want to use that.
