### PR TITLE
Simplify the logic in the SendsLine function

### DIFF
--- a/src/iFixit/StatsD.php
+++ b/src/iFixit/StatsD.php
@@ -226,21 +226,27 @@ class StatsD {
     * 
     * @param array $lines The lines to be sent to the stats-Server
     */
-   protected static function sendLines($lines) {
-      $out = array();
-      $chunkSize = 0;
-      $i = 0; $lineCount = count($lines);
+   protected static function sendLines(array $lines) {
+      $out = [];
+
+      $packetSize = 0;
+      $i = 0;
+      $lineCount = count($lines);
+
       while ($i < $lineCount) {
          $line = static::$prefix . $lines[$i];
          $len = strlen($line) + 1;
-         $chunkSize += $len;
-         if ($chunkSize > self::MAX_PACKET_SIZE) {
+
+         $packetFull = $packetSize + $len > self::MAX_PACKET_SIZE;
+         if ($packetFull) {
             static::sendAsUDP(implode("\n", $out));
-            $out = array($line);
-            $chunkSize = $len;
-         } else {
-            $out[] = $line;
+            $out = [];
+            $packetSize = 0;
          }
+
+         $out[] = $line;
+         $packetSize += $len;
+
          $i++;
       }
       static::sendAsUDP(implode("\n", $out));


### PR DESCRIPTION
That was convoluted, and it took a pair of use three reads to grok. Get
rid of the else, and retouch the naming.

Hopefully this helps with legibility.

CC @andyg0808 