### PR TITLE
travis: run on php 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - 5.3
+  - 7.1
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev


### PR DESCRIPTION
php 5.3 isn't supported on the normal travis platform

Closes #11